### PR TITLE
add Python3 compatibility

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,11 @@
 from __future__ import print_function
 from flask import Flask, json, render_template
 import flask_slides
-import urllib2
+try:
+	from urllib2 import urlopen
+except ImportError:
+	# python3 uses urllib.request.urlopen
+	from urllib.request import urlopen
 # pylint: disable=W0312
 
 FLASK_SLIDES = flask_slides.FlaskSlides()
@@ -109,7 +113,7 @@ def error():
 @APP.route('/prox/<path:request_path>')
 def prox(request_path):
 	"""Acts as a trivial example of a proxy, for use in presentation."""
-	data = urllib2.urlopen(request_path).read()
+	data = urlopen(request_path).read()
 	return data
 
 

--- a/directory_cache.py
+++ b/directory_cache.py
@@ -66,7 +66,10 @@ def get_file_contents(file_name):
 	"""Read a text file conveniently and properly."""
 	ret_val = None
 	with open(file_name, 'r') as tmp_file:
-		ret_val = tmp_file.read().decode('utf-8')
+		ret_val = tmp_file.read()
+		if hasattr(ret_val, 'decode'):
+			# python2 decode to utf-8
+			ret_val = ret_val.decode('utf-8')
 	return ret_val
 
 def get_dir_files(path):

--- a/directory_cache.py
+++ b/directory_cache.py
@@ -62,10 +62,10 @@ def jdump(obj):
 	return json.dumps(obj, sort_keys=True, indent=4, separators=(',', ': '))
 
 # Gets contents of a file
-def get_file_contents(file_name):
+def get_file_contents(filename):
 	"""Read a text file conveniently and properly."""
 	ret_val = None
-	with open(file_name, 'r') as tmp_file:
+	with open(filename, 'r') as tmp_file:
 		ret_val = tmp_file.read()
 		if hasattr(ret_val, 'decode'):
 			# python2 decode to utf-8
@@ -85,11 +85,10 @@ def build_file_size_dir(path):
 
 def strip_ext(files):
 	"""Strips the extension from a filename or list of filenames"""
-	if   isinstance(files, basestring):
-		return '.'.join(files.split('.')[:-1])
-	elif isinstance(files, list):
+	if isinstance(files, list):
 		# List comprehension of the above stripping process.
 		return ['.'.join(f.split('.')[:-1]) for f in files]
+	return '.'.join(files.split('.')[:-1])
 
 
 class DirectoryCache(object):

--- a/flask_slides.py
+++ b/flask_slides.py
@@ -4,6 +4,7 @@
 from __future__ import print_function
 from os.path import join, abspath
 import directory_cache
+from directory_cache import strip_ext, jdump
 import markdown
 import os.path
 import json
@@ -29,21 +30,9 @@ import os
 #
 
 
-def jdump(obj):
-	"""Return json string representation of object"""
-	return json.dumps(obj, sort_keys=True, indent=4, separators=(',', ': '))
 def jprint(obj):
 	"""Print a json representation of a given object"""
 	print(jdump(obj))
-
-def strip_ext(files):
-	"""Strips the extension from a filename or list of filenames"""
-	if   isinstance(files, basestring):
-		return '.'.join(files.split('.')[:-1])
-	elif isinstance(files, list):
-		# List comprehension of the above stripping process.
-		return ['.'.join(f.split('.')[:-1]) for f in files]
-
 
 
 class FlaskSlides(object):


### PR DESCRIPTION
changed a few things to add python3 compatibility:

decode to utf-8 only if file input has "decode" function
if importing urllib2.urlopen (py2) fails, import urllib.request.urlopen (py3) 
removed basestring instance check (py2 only)
remove duplicate functions strip_ext() and jdump() from flask_slides.py
and instead import them from directory_cache.py
